### PR TITLE
Adjust payouts by deducting overpayments 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,37 @@ Payouts 2 stats:
 Payouts in both files:  <redacted>
 ```
 
+### Deduct overpayments from payouts
+```shell
+compare-payouts -deduct -f1 Saturn-FVM-Payouts-2024-03.csv -f2 Saturn-FVM-overpaid-2024-02.csv
+
+Reducing current payout for <redacted>
+  payout before deduction: 19.888213373800003
+  overpayment amount: 24.084187046100002
+  payout after deduction: 0
+  remaining overpayment: 4.195973672299999
+
+Reducing current payout for <redacted>
+  payout before deduction: 35.134526091699996
+  overpayment amount: 50.437306431100005
+  payout after deduction: 0
+  remaining overpayment: 15.302780339400009
+
+Overpaid address <redacted> not found in payouts
+Reducing current payout for <redacted>
+  payout before deduction: 29.7999360835
+  overpayment amount: 37.3769563082
+  payout after deduction: 0
+  remaining overpayment: 7.5770202247
+
+...
+
+--------------------------------
+Total payouts before deductions: 29388.1022690668 FIL
+Total payout adjustment:         -9507.476867757496 FIL
+Total payouts after deductions:  19880.625401309302 FIL
+Total leftover overpayments:     1276.6633122924998 FIL
+
+Wrote adjusted payouts to: payouts/Saturn-FVM-Payouts-2024-03-adjusted.csv
+Wrote leftover overpayments to: payouts/Saturn-FVM-overpaid-2024-02-leftover.csv
+```

--- a/deduct.go
+++ b/deduct.go
@@ -24,7 +24,8 @@ func deduct(csv1Path, csv2Path string) error {
 		return err
 	}
 
-	var leftover, totalPaid, totalAdjusted float64
+	sumBefore, _ := statsFIL(payouts)
+	var leftover, totalAdjusted float64
 
 	for addr, over := range overpaid {
 		payout, ok := payouts[addr]
@@ -47,7 +48,6 @@ func deduct(csv1Path, csv2Path string) error {
 			totalAdjusted += over.fil
 			over.fil = 0
 			delete(overpaid, addr)
-			totalPaid += payout.fil
 		} else {
 			totalAdjusted += over.fil
 			delete(payouts, addr)
@@ -59,10 +59,13 @@ func deduct(csv1Path, csv2Path string) error {
 		fmt.Println("  remaining overpayment:", over.fil)
 		fmt.Println()
 	}
-	fmt.Println("------------------------------")
-	fmt.Println("Total payouts after deductions:", totalPaid, "FIL")
-	fmt.Println("Total leftover overpayments:", leftover, "FIL")
-	fmt.Println("Total payout ajdustment:", -totalAdjusted, "FIL")
+	sumAfter, _ := statsFIL(payouts)
+	fmt.Println("--------------------------------")
+	fmt.Println("Total payouts before deductions:", sumBefore, "FIL")
+	fmt.Println("Total payout adjustment:        ", -totalAdjusted, "FIL")
+	fmt.Println("Total payouts after deductions: ", sumAfter, "FIL")
+	fmt.Println("Total leftover overpayments:    ", leftover, "FIL")
+
 	fmt.Println()
 
 	adjustedName := strings.TrimSuffix(csv1Path, ".csv") + adjustedSuffix + ".csv"

--- a/deduct.go
+++ b/deduct.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	adjustedSuffix = "-adjusted"
+	leftoverSuffix = "-leftover"
+)
+
+func deduct(csv1Path, csv2Path string) error {
+	payouts, err := readPayoutsCSV(csv1Path)
+	if err != nil {
+		return err
+	}
+
+	overpaid, err := readPayoutsCSV(csv2Path)
+	if err != nil {
+		return err
+	}
+
+	var leftover, totalPaid, totalAdjusted float64
+
+	for addr, over := range overpaid {
+		payout, ok := payouts[addr]
+		if !ok {
+			fmt.Println("Overpaid address", addr, "not found in payouts")
+			continue
+		}
+		fmt.Println("Reducing current payout for", addr)
+		fmt.Println("  payout before deduction:", payout.fil)
+		fmt.Println("  overpayment amount:", over.fil)
+
+		if over.fil > payout.fil {
+			over.fil -= payout.fil
+			totalAdjusted += payout.fil
+			payout.fil = 0
+			delete(payouts, addr)
+			leftover += over.fil
+		} else if over.fil < payout.fil {
+			payout.fil -= over.fil
+			totalAdjusted += over.fil
+			over.fil = 0
+			delete(overpaid, addr)
+			totalPaid += payout.fil
+		} else {
+			totalAdjusted += over.fil
+			delete(payouts, addr)
+			delete(overpaid, addr)
+			payout.fil = 0
+			over.fil = 0
+		}
+		fmt.Println("  payout after deduction:", payout.fil)
+		fmt.Println("  remaining overpayment:", over.fil)
+		fmt.Println()
+	}
+	fmt.Println("------------------------------")
+	fmt.Println("Total payouts after deductions:", totalPaid, "FIL")
+	fmt.Println("Total leftover overpayments:", leftover, "FIL")
+	fmt.Println("Total payout ajdustment:", -totalAdjusted, "FIL")
+	fmt.Println()
+
+	adjustedName := strings.TrimSuffix(csv1Path, ".csv") + adjustedSuffix + ".csv"
+	err = writePayoutsCSV(adjustedName, payouts)
+	if err != nil {
+		return fmt.Errorf("failed to write adjusted payouts csv file: %w", err)
+	}
+	fmt.Println("Wrote adjusted payouts to:", adjustedName)
+
+	if len(overpaid) != 0 {
+		leftoverName := strings.TrimSuffix(csv2Path, ".csv") + leftoverSuffix + ".csv"
+		err = writePayoutsCSV(leftoverName, overpaid)
+		if err != nil {
+			return fmt.Errorf("failed to write loetover overpayments csv file: %w", err)
+		}
+		fmt.Println("Wrote leftover overpayments to:", leftoverName)
+	}
+
+	return nil
+}
+
+func writePayoutsCSV(filePath string, records map[string]*record) error {
+	f, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("opening csv file for writing: %w", err)
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	err = w.Write([]string{"Recipient", "FIL", "Method", "Params"})
+	if err != nil {
+		return err
+	}
+	recStrs := make([]string, 4)
+	for addr, rec := range records {
+		recStrs[0] = addr
+		recStrs[1] = strconv.FormatFloat(rec.fil, 'f', -1, 64)
+		recStrs[2] = rec.method
+		recStrs[3] = rec.params
+		if err = w.Write(recStrs); err != nil {
+			return fmt.Errorf("writing record: %w", err)
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	var (
+		csv1Path   string
+		csv2Path   string
+		opDeduct   bool
+		top1, top2 int
+	)
+	flag.BoolVar(&opDeduct, "deduct", false, "Deduce overpayments in file2 from payouts in file1")
+	flag.StringVar(&csv1Path, "f1", "", "first payouts csv file")
+	flag.StringVar(&csv2Path, "f2", "", "second payouts csv file")
+	flag.IntVar(&top1, "top1", 0, "limit file 1 to N records with highest FIL")
+	flag.IntVar(&top2, "top2", 0, "limit file 2 to N records with highest FIL")
+	flag.Parse()
+
+	if csv1Path == "" {
+		fmt.Fprintln(os.Stderr, "missing value for -f1")
+		os.Exit(1)
+	}
+
+	if csv2Path == "" {
+		fmt.Fprintln(os.Stderr, "missing value for -f2")
+		os.Exit(1)
+	}
+
+	var err error
+	if opDeduct {
+		if top1 != 0 || top2 != 0 {
+			fmt.Fprintln(os.Stderr, "-top1 and -top2 are not available with -deduct")
+			os.Exit(1)
+		}
+		err = deduct(csv1Path, csv2Path)
+	} else {
+		err = compare(csv1Path, csv2Path, top1, top2)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
The `-deduct` flag causes the overpayments in the 2nd CSV file to be deducted from the payouts in the first CVS file. A new adjusted payouts is created and any leftover overpayments are written to a leftover overpayments CSV file.